### PR TITLE
SWRS ECCC import dag triggers CIIP deploy db

### DIFF
--- a/docker/cas-airflow/root/usr/local/airflow/airflow.cfg
+++ b/docker/cas-airflow/root/usr/local/airflow/airflow.cfg
@@ -62,7 +62,7 @@ hostname_callable = socket:getfqdn
 
 # Default timezone in case supplied date times are naive
 # can be utc (default), system, or any IANA timezone string (e.g. Europe/Amsterdam)
-default_timezone = utc
+default_timezone = America/Vancouver
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor, DaskExecutor, KubernetesExecutor

--- a/docker/cas-airflow/root/usr/local/airflow/airflow.cfg
+++ b/docker/cas-airflow/root/usr/local/airflow/airflow.cfg
@@ -593,7 +593,7 @@ scheduler_zombie_task_threshold = 300
 # will not do scheduler catchup if this is False,
 # however it can be set on a per DAG basis in the
 # DAG definition (catchup)
-catchup_by_default = True
+catchup_by_default = False
 
 # This changes the batch size of queries in the scheduling main loop.
 # If this is too high, SQL query performance may be impacted by one


### PR DESCRIPTION
+ setting default timezone to America/Vancouver to ensure that DAGs is run outside of business hours
+ set catchup_by_default to false to avoid running many DAGs when turning them on