### PR TITLE
fix: exec_in_pod missing a param

### DIFF
--- a/dags/exec_in_pod.py
+++ b/dags/exec_in_pod.py
@@ -6,7 +6,7 @@ from kubernetes.stream import stream
 from kubernetes.client.rest import ApiException
 from pprint import pprint
 
-def get_pod_name(deployment_name, namespace, selector):
+def get_pod_name(deployment_name, namespace, selector=False):
   try:
       kubernetes.config.load_incluster_config()
   except:
@@ -16,7 +16,10 @@ def get_pod_name(deployment_name, namespace, selector):
   api_instance = kubernetes.client.CoreV1Api(kubernetes.client.ApiClient(configuration))
 
   try:
-      pod_label_selector="app=" + deployment_name + ", " + selector
+      if selector:
+        pod_label_selector="app=" + deployment_name + ", " + selector
+      else:
+        pod_label_selector="app=" + deployment_name
       api_response = api_instance.list_namespaced_pod(namespace, label_selector=pod_label_selector, pretty='true')
       for x in api_response.items:
         if deployment_name in x.metadata.name:
@@ -24,7 +27,7 @@ def get_pod_name(deployment_name, namespace, selector):
   except ApiException as e:
       print("Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e)
 
-def exec_in_pod(deployment_name, namespace, command, selector):
+def exec_in_pod(deployment_name, namespace, command, selector=False):
   try:
       kubernetes.config.load_incluster_config()
   except:
@@ -33,7 +36,7 @@ def exec_in_pod(deployment_name, namespace, command, selector):
   configuration = kubernetes.client.Configuration()
   api_instance = kubernetes.client.CoreV1Api(kubernetes.client.ApiClient(configuration))
 
-  name = get_pod_name(deployment_name, namespace)
+  name = get_pod_name(deployment_name, namespace, selector)
 
   try:
       api_response = stream(api_instance.connect_post_namespaced_pod_exec, name, namespace, command=command, stderr=True,


### PR DESCRIPTION
get_pod_name function call was missing the new 'selector' param
make 'selector' optional (default to False)