### PR TITLE
fix: increasing the webserver worker timeout to 5 minutes

### DIFF
--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -103,6 +103,7 @@ airflow:
     webserver:
       username: "cas-airflow-admin"
       password: "$(DEFAULT_USER_PASS)"
+      web_server_worker_timeout: 300
 
     smtp:
       smtp_host: apps.smtp.gov.bc.ca


### PR DESCRIPTION
mitigating the effects of https://github.com/apache/airflow/issues/14034 before we upgrade to 2.0.2
- [x] editing values.yaml
- [x] testing the helm chart manually