### PR TITLE
chore: add owner_reference to job templates

### DIFF
--- a/dags/trigger_k8s_cronjob.py
+++ b/dags/trigger_k8s_cronjob.py
@@ -38,6 +38,16 @@ def trigger_k8s_cronjob(cronjob_name, namespace):
         cronjob.spec.job_template.metadata.name = str(
             date_str + cronjob.metadata.name)[:63]
 
+        # Create an OwnerReference object and add it to the metadata.owner_references list
+        owner_reference = client.V1OwnerReference(
+          api_version=cronjob.api_version,
+          controller=True,
+          kind=cronjob.kind,
+          name=cronjob.metadata.name,
+          uid=cronjob.metadata.uid
+        )
+        cronjob.spec.job_template.metadata.owner_references = [owner_reference]
+
         try:
             # Create a job from the job_template of the cronjob
             created_job = api.create_namespaced_job(


### PR DESCRIPTION
The previous implementation (which did not work) created the owner_reference object like this:
owner_reference = {
"api_version": cronjob.metadata.api_version,
... 
}

metadata.owner_references is a list that expects a V1OwnerReference object. This PR properly creates that object via the api and then adds it to the owner_references list.