### PR TITLE
chore: add fallback values for api_version & kind

### DIFF
--- a/dags/trigger_k8s_cronjob.py
+++ b/dags/trigger_k8s_cronjob.py
@@ -40,9 +40,9 @@ def trigger_k8s_cronjob(cronjob_name, namespace):
 
         # Create an OwnerReference object and add it to the metadata.owner_references list
         owner_reference = client.V1OwnerReference(
-          api_version=cronjob.api_version,
+          api_version=cronjob.api_version or 'batch/v1beta1',
           controller=True,
-          kind=cronjob.kind,
+          kind=cronjob.kind or 'CronJob',
           name=cronjob.metadata.name,
           uid=cronjob.metadata.uid
         )


### PR DESCRIPTION
Not sure why cronjob.api_version would be `None`, but that was the error our airflow dag log was complaining about.
This PR adds fallback values (`api_version='batch/v1beta1'` and `kind='CronJob'`) when creating the V1OwnerReference object.