### PR TITLE
fix: set dag conf default to base64

### DIFF
--- a/helm/cas-airflow-dag-trigger/templates/dag-trigger-job.yaml
+++ b/helm/cas-airflow-dag-trigger/templates/dag-trigger-job.yaml
@@ -51,4 +51,4 @@ spec:
           - /usr/bin/env
           - bash
           - -c
-          - ./airflow-dag-trigger.sh {{ .Values.dagId }} {{ .Values.dagConfiguration | default "{}" | quote }}
+          - ./airflow-dag-trigger.sh {{ .Values.dagId }} {{ .Values.dagConfiguration | default "e30K" | quote }}

--- a/helm/cas-airflow-dag-trigger/values.yaml
+++ b/helm/cas-airflow-dag-trigger/values.yaml
@@ -1,7 +1,7 @@
 # Values
 airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
 dagId: null
-dagConfiguration: "{}"
+dagConfiguration: "e30K"
 helm:
   # hook should be null if the job shouldn't be run as a hook
   hook: "pre-upgrade,pre-install"


### PR DESCRIPTION
Using base64 to encode the json string because of helm limitations.