### PR TITLE
feat: grant Airflow access to the CIF namespace

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,20 +15,22 @@ The dags directory contains the various workflows (Directed Acyclic Graphs)
 - The KubernetesPodOperator allows us to create Pods on Kubernetes.
   - It gives us the freedom to run the command in any arbitrary image, sandboxing the job run inside a docker container.
   - It allows us to select in which namespace to run the job.
-- [`Airflow Kubernetes`](https://airflow.apache.org/docs/stable/kubernetes.html 'Airflow Kubernetes')
+- [`Airflow Kubernetes`](https://airflow.apache.org/docs/stable/kubernetes.html "Airflow Kubernetes")
 
 ## CI/CD
 
 The docker images are built on CircleCI for every commit, and pushed to CAS' google cloud registry if the build occurs on the `develop` or `master` branch, or if the commit is tagged.
 
 Deployement is done with Shipit, using the helm charts defined in the `helm` folder
-  - the `helm install` command should specify namespaces for the different cas application: `helm install --set namespaces.airflow=<< >> --set namespaces.ggircs=<< >> --set namespaces.ciip=<< >>`
+
+- the `helm install` command should specify namespaces for the different CAS applications: `helm install --set namespaces.airflow=<< >> --set namespaces.ggircs=<< >> --set namespaces.ciip=<< >> --set namespaces.cif=<< >>`
 
 There are a couple manual steps required for installation (the first deployment) at the moment:
 
 1. Prior to deploying, the namespace where airflow is deployed should have:
-  - A "github-registry" secret, containing the pull secrets to the docker registry. This should be taken care of by [cas-pipeline](https://github.com/bcgov/cas-pipeline/)'s `make provision`.
-  - An "airflow-default-user-password" secret. This will have airflow create a 'cas-aiflow-admin' user with this password.
+
+- A "github-registry" secret, containing the pull secrets to the docker registry. This should be taken care of by [cas-pipeline](https://github.com/bcgov/cas-pipeline/)'s `make provision`.
+- An "airflow-default-user-password" secret. This will have airflow create a 'cas-aiflow-admin' user with this password.
 
 2. Deploy with shipit
 
@@ -41,18 +43,17 @@ There are a couple manual steps required for installation (the first deployment)
 - [ ] authentication should be done with GitHub (allowing members of https://github.com/orgs/bcgov/teams/cas-developers)
 - [ ] automate the creation of connections on installation
 
-
 ## Contributing
+
 ### Cloning
 
 ```bash
 git clone git@github.com:bcgov/cas-airflow.git ~/cas-airflow && cd $_
 git submodule update --init
 ```
+
 This repository contains the DAGs as well as the helm chart.
 It submodules airflow through the cas-airflow-upstream repository, to use its helm chart as a dependency - and will eventually reference the official airflow instead.
-
-
 
 ### Getting started
 
@@ -75,7 +76,6 @@ asdf reshim
 ```
 
 Be sure to set the `$AIRFLOW_HOME` environment variable if this repository was cloned to a path other than `~/airflow`.
-
 
 ```bash
 airflow db init

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,6 +14,7 @@ helm upgrade --install --timeout 900s \
   --set namespaces.airflow="$AIRFLOW_NAMESPACE_PREFIX-$ENVIRONMENT" \
   --set namespaces.ggircs="$GGIRCS_NAMESPACE_PREFIX-$ENVIRONMENT" \
   --set namespaces.ciip="$CIIP_NAMESPACE_PREFIX-$ENVIRONMENT" \
+  --set namespaces.cif="$CIF_NAMESPACE_PREFIX-$ENVIRONMENT" \
   --set airflow.defaultAirflowTag="$git_sha1" \
   cas-airflow ./helm/cas-airflow
 

--- a/helm/cas-airflow/templates/scheduler/scheduler-roleBinding.yaml
+++ b/helm/cas-airflow/templates/scheduler/scheduler-roleBinding.yaml
@@ -1,4 +1,4 @@
-{{- range (list .Release.Namespace .Values.namespaces.ggircs .Values.namespaces.ciip) }}
+{{- range (list .Release.Namespace .Values.namespaces.ggircs .Values.namespaces.ciip .Values.namespaces.cif) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -8,7 +8,7 @@ metadata:
   labels:
     release: {{ $.Release.Name }}
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-{{ include "cas-airflow.labels" $ | nindent 4 }}  
+{{ include "cas-airflow.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/cas-airflow/templates/workers/worker-roleBinding.yaml
+++ b/helm/cas-airflow/templates/workers/worker-roleBinding.yaml
@@ -1,4 +1,4 @@
-{{- range (list .Release.Namespace .Values.namespaces.ggircs .Values.namespaces.ciip) }}
+{{- range (list .Release.Namespace .Values.namespaces.ggircs .Values.namespaces.ciip .Values.namespaces.cif) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -65,6 +65,9 @@ airflow:
     - envName: CIIP_NAMESPACE
       secretName: cas-namespaces
       secretKey: ciip-namespace
+    - envName: CIF_NAMESPACE
+      secretName: cas-namespaces
+      secretKey: cif-namespace
 
   # Airflow database config
   data:


### PR DESCRIPTION
- adds the CIF namespace to the list of namespaces where Airflow has permissions to run jobs
- adds the `CIF_NAMESPACE` env variable to the airflow containers, making it usable in DAGs