### PR TITLE
feat: add exponential backoff to k8s job

### DIFF
--- a/dags/trigger_k8s_cronjob.py
+++ b/dags/trigger_k8s_cronjob.py
@@ -14,8 +14,10 @@ def get_cronjob(cronjob_name, namespace, batchApi):
             if job.metadata.name == cronjob_name:
                 return job
     except ApiException as e:
-        logging.critical(
-            "Exception when calling BatchV1Api->list_namespaced_cron_job: %s\n" % e)
+        error_string = "Exception when calling BatchV1Api->list_namespaced_cron_job: {}".format(e)
+        logging.critical(error_string)
+        raise Exception from e
+
     return False
 
 # Get the pod name for the newly created job
@@ -83,7 +85,7 @@ def trigger_k8s_cronjob(cronjob_name, namespace):
 
          # Wait a bit initially for the job to be created
         time.sleep(10)
-        pod_name = retry_with_backoff(get_pod_name(namespace, pod_label_selector, core_v1)) 
+        pod_name = retry_with_backoff(get_pod_name(namespace, pod_label_selector, core_v1))
 
         try:
             # Get the status of the newly created job

--- a/dags/trigger_k8s_cronjob.py
+++ b/dags/trigger_k8s_cronjob.py
@@ -20,15 +20,10 @@ def get_cronjob(cronjob_name, namespace, batchApi):
 
 # Get the pod name for the newly created job
 def get_pod_name(namespace, pod_label_selector, core_v1):
-    try:
-        pods_list = core_v1.list_namespaced_pod(
-            namespace, label_selector=pod_label_selector, timeout_seconds=10)
-        pod_name = pods_list.items[0].metadata.name
-        return pod_name
-    except ApiException as e:
-        logging.critical(
-            "Exception when calling CoreV1Api->list_namespaced_pod: {}\n".format(e))
-        raise
+    pods_list = core_v1.list_namespaced_pod(
+        namespace, label_selector=pod_label_selector, timeout_seconds=10)
+    pod_name = pods_list.items[0].metadata.name
+    return pod_name
 
 
 # Creates a job from a cronjob job_template
@@ -85,7 +80,7 @@ def trigger_k8s_cronjob(cronjob_name, namespace):
 
          # Wait a bit initially for the job to be created
         time.sleep(10)
-        pod_name = retry_with_backoff(get_pod_name(namespace, pod_label_selector, core_v1))
+        pod_name = retry_with_backoff(lambda: get_pod_name(namespace, pod_label_selector, core_v1))
 
         try:
             # Get the status of the newly created job

--- a/dags/trigger_k8s_cronjob.py
+++ b/dags/trigger_k8s_cronjob.py
@@ -6,18 +6,20 @@ import logging
 import random
 
 def retry_with_backoff(fn, retries = 6, backoff_in_seconds = 1):
-  x = 0
-  while True:
-    try:
-      return fn()
-    except:
-      if x == retries:
-        raise
+    x = 0
+    while True:
+        try:
+            return fn()
+        except:
+            if x == retries:
+                raise
 
-      sleep = (backoff_in_seconds * 2 ** x + 
-               random.uniform(0, 1))
-      time.sleep(sleep)
-      x += 1
+            sleep = (backoff_in_seconds * 2 ** x + 
+                    random.uniform(0, 1))
+            logging.critical(
+                "Retrying in {backoff} seconds".format(backoff=sleep))
+            time.sleep(sleep)
+        x += 1
 
 # Retrieves a cron_job by name & namespace
 def get_cronjob(cronjob_name, namespace, batchApi):

--- a/dags/trigger_k8s_cronjob.py
+++ b/dags/trigger_k8s_cronjob.py
@@ -14,10 +14,8 @@ def get_cronjob(cronjob_name, namespace, batchApi):
             if job.metadata.name == cronjob_name:
                 return job
     except ApiException as e:
-        error_string = "Exception when calling BatchV1Api->list_namespaced_cron_job: {}".format(e)
-        logging.critical(error_string)
-        raise Exception from e
-
+        logging.critical(
+            "Exception when calling BatchV1Api->list_namespaced_cron_job: {}".format(e))
     return False
 
 # Get the pod name for the newly created job
@@ -29,7 +27,9 @@ def get_pod_name(namespace, pod_label_selector, core_v1):
         return pod_name
     except ApiException as e:
         logging.critical(
-            "Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e)
+            "Exception when calling CoreV1Api->list_namespaced_pod: {}\n".format(e))
+        raise
+
 
 # Creates a job from a cronjob job_template
 def trigger_k8s_cronjob(cronjob_name, namespace):

--- a/dags/trigger_k8s_cronjob.py
+++ b/dags/trigger_k8s_cronjob.py
@@ -5,7 +5,7 @@ import time
 import logging
 import random
 
-def retry_with_backoff(fn, retries = 5, backoff_in_seconds = 1):
+def retry_with_backoff(fn, retries = 6, backoff_in_seconds = 1):
   x = 0
   while True:
     try:

--- a/dags/trigger_k8s_cronjob.py
+++ b/dags/trigger_k8s_cronjob.py
@@ -1,25 +1,9 @@
+from dags.utils.backoff import retry_with_backoff
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 import datetime
 import time
 import logging
-import random
-
-def retry_with_backoff(fn, retries = 6, backoff_in_seconds = 1):
-    x = 0
-    while True:
-        try:
-            return fn()
-        except:
-            if x == retries:
-                raise
-
-            sleep = (backoff_in_seconds * 2 ** x + 
-                    random.uniform(0, 1))
-            logging.critical(
-                "Retrying in {backoff} seconds".format(backoff=sleep))
-            time.sleep(sleep)
-        x += 1
 
 # Retrieves a cron_job by name & namespace
 def get_cronjob(cronjob_name, namespace, batchApi):
@@ -33,6 +17,17 @@ def get_cronjob(cronjob_name, namespace, batchApi):
         logging.critical(
             "Exception when calling BatchV1Api->list_namespaced_cron_job: %s\n" % e)
     return False
+
+# Get the pod name for the newly created job
+def get_pod_name(namespace, pod_label_selector, core_v1):
+    try:
+        pods_list = core_v1.list_namespaced_pod(
+            namespace, label_selector=pod_label_selector, timeout_seconds=10)
+        pod_name = pods_list.items[0].metadata.name
+        return pod_name
+    except ApiException as e:
+        logging.critical(
+            "Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e)
 
 # Creates a job from a cronjob job_template
 def trigger_k8s_cronjob(cronjob_name, namespace):
@@ -86,20 +81,9 @@ def trigger_k8s_cronjob(cronjob_name, namespace):
         # Create a label_selector from the job's UID
         pod_label_selector = "controller-uid=" + controllerUid
 
-        def get_pod_name(pod_label_selector):
-            try:
-                # Get the pod name for the newly created job
-                pods_list = core_v1.list_namespaced_pod(
-                    namespace, label_selector=pod_label_selector, timeout_seconds=10)
-                pod_name = pods_list.items[0].metadata.name
-                return pod_name
-            except ApiException as e:
-                logging.critical(
-                    "Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e)
-
          # Wait a bit initially for the job to be created
         time.sleep(10)
-        pod_name = retry_with_backoff(get_pod_name(pod_label_selector)) 
+        pod_name = retry_with_backoff(get_pod_name(namespace, pod_label_selector, core_v1)) 
 
         try:
             # Get the status of the newly created job

--- a/dags/utils/backoff.py
+++ b/dags/utils/backoff.py
@@ -6,18 +6,19 @@ import sys
 logger = logging.getLogger()
 
 def retry_with_backoff(fn, retries = 10, backoff_in_seconds = 1):
-    x = 0
-    while True:
-        try:
-            return fn()
-        except Exception as e:
-            if x == retries:
-                raise
-            sleep = (backoff_in_seconds * 2 ** x +
-                    random.uniform(0, 1))
 
-            logger.critical("Exception: {} {}\n from function {}"
-                .format(sys.exc_info()[0], e, fn))
-            logger.critical("Attempt {}, retrying in {} seconds\n".format(x, round(sleep)))
-            time.sleep(sleep)
-        x += 1
+    try:
+        return fn()
+    except Exception as e:
+
+        logger.critical("Exception: {} {}\n from function {}"
+            .format(sys.exc_info()[0], e, fn))
+
+        if retries <= 0:
+            raise
+        sleep = (backoff_in_seconds + random.uniform(0, 1))
+
+        logger.critical("Retrying in {} seconds\n".format(round(sleep)))
+        time.sleep(sleep)
+
+        retry_with_backoff(fn, retries-1, backoff_in_seconds * 2 )

--- a/dags/utils/backoff.py
+++ b/dags/utils/backoff.py
@@ -1,17 +1,24 @@
 import time
 import logging
 import random
+import sys
 
 logger = logging.getLogger()
 
 def retry_with_backoff(fn, retries = 10, backoff_in_seconds = 1):
     try:
         return fn()
-    except:
+    except Exception as e:
+        print()
         if retries <= 0:
             raise
+
         sleep = (backoff_in_seconds * 2 ** retries +
                 random.uniform(0, 1))
-        logger.critical("Retrying in {} seconds".format(round(sleep)))
+
+        logger.critical("Exception: {} {}\n from function {}"
+            .format(sys.exc_info()[0], e, fn))
+        logger.critical("Retrying in {} seconds\n".format(round(sleep)))
+
         time.sleep(sleep)
         retry_with_backoff(fn, retries - 1, backoff_in_seconds)

--- a/dags/utils/backoff.py
+++ b/dags/utils/backoff.py
@@ -1,4 +1,3 @@
-import asyncio
 import time
 import logging
 import random
@@ -7,38 +6,13 @@ def retry_with_backoff(fn, retries = 6, backoff_in_seconds = 1):
     x = 0
     while True:
         try:
-            print('trying to return function')
             return fn()
         except:
-            print('except {}'.format(x))
             if x == retries:
-                return None
-            sleep = (backoff_in_seconds * 2 ** x + 
+                raise
+            sleep = (backoff_in_seconds * 2 ** x +
                     random.uniform(0, 1))
             logging.critical(
                 "Retrying in {backoff} seconds".format(backoff=sleep))
             time.sleep(sleep)
         x += 1
-
-def test_retry_with_backoff(monkeypatch):
-    """
-    GIVEN a monkeypatched version of an api call 
-    WHEN example1() is called
-    THEN the api call returns after x seconds 
-    """
-    
-    # def mock_get_pod_name():
-    #     async def mock_return():
-    #         await asyncio.sleep(5) 
-    #         return 'example_name'
-    #     try: 
-    #         mock_return() 
-    #     except: 
-    #         logging.critical('error')
-
-    # pod_name = retry_with_backoff(mock_get_pod_name)
-
-    retry_with_backoff(monkeypatch, 2)
-
-    assert 1==1
-    

--- a/dags/utils/backoff.py
+++ b/dags/utils/backoff.py
@@ -1,0 +1,44 @@
+import asyncio
+import time
+import logging
+import random
+
+def retry_with_backoff(fn, retries = 6, backoff_in_seconds = 1):
+    x = 0
+    while True:
+        try:
+            print('trying to return function')
+            return fn()
+        except:
+            print('except {}'.format(x))
+            if x == retries:
+                return None
+            sleep = (backoff_in_seconds * 2 ** x + 
+                    random.uniform(0, 1))
+            logging.critical(
+                "Retrying in {backoff} seconds".format(backoff=sleep))
+            time.sleep(sleep)
+        x += 1
+
+def test_retry_with_backoff(monkeypatch):
+    """
+    GIVEN a monkeypatched version of an api call 
+    WHEN example1() is called
+    THEN the api call returns after x seconds 
+    """
+    
+    # def mock_get_pod_name():
+    #     async def mock_return():
+    #         await asyncio.sleep(5) 
+    #         return 'example_name'
+    #     try: 
+    #         mock_return() 
+    #     except: 
+    #         logging.critical('error')
+
+    # pod_name = retry_with_backoff(mock_get_pod_name)
+
+    retry_with_backoff(monkeypatch, 2)
+
+    assert 1==1
+    

--- a/dags/utils/backoff.py
+++ b/dags/utils/backoff.py
@@ -2,6 +2,8 @@ import time
 import logging
 import random
 
+logger = logging.getLogger()
+
 def retry_with_backoff(fn, retries = 6, backoff_in_seconds = 1):
     x = 0
     while True:
@@ -12,7 +14,7 @@ def retry_with_backoff(fn, retries = 6, backoff_in_seconds = 1):
                 raise
             sleep = (backoff_in_seconds * 2 ** x +
                     random.uniform(0, 1))
-            logging.critical(
+            logger.critical(
                 "Retrying in {backoff} seconds".format(backoff=sleep))
             time.sleep(sleep)
         x += 1

--- a/dags/utils/backoff.py
+++ b/dags/utils/backoff.py
@@ -6,19 +6,18 @@ import sys
 logger = logging.getLogger()
 
 def retry_with_backoff(fn, retries = 10, backoff_in_seconds = 1):
-    try:
-        return fn()
-    except Exception as e:
-        print()
-        if retries <= 0:
-            raise
+    x = 0
+    while True:
+        try:
+            return fn()
+        except Exception as e:
+            if x == retries:
+                raise
+            sleep = (backoff_in_seconds * 2 ** x +
+                    random.uniform(0, 1))
 
-        sleep = (backoff_in_seconds * 2 ** retries +
-                random.uniform(0, 1))
-
-        logger.critical("Exception: {} {}\n from function {}"
-            .format(sys.exc_info()[0], e, fn))
-        logger.critical("Retrying in {} seconds\n".format(round(sleep)))
-
-        time.sleep(sleep)
-        retry_with_backoff(fn, retries - 1, backoff_in_seconds)
+            logger.critical("Exception: {} {}\n from function {}"
+                .format(sys.exc_info()[0], e, fn))
+            logger.critical("Attempt {}, retrying in {} seconds\n".format(x, round(sleep)))
+            time.sleep(sleep)
+        x += 1

--- a/dags/utils/backoff.py
+++ b/dags/utils/backoff.py
@@ -5,15 +5,13 @@ import random
 logger = logging.getLogger()
 
 def retry_with_backoff(fn, retries = 10, backoff_in_seconds = 1):
-    x = 0
-    while True:
-        try:
-            return fn()
-        except:
-            if x == retries:
-                raise
-            sleep = (backoff_in_seconds * 2 ** x +
-                    random.uniform(0, 1))
-            logger.critical("Attempt {}, retrying in {} seconds".format(x, round(sleep)))
-            time.sleep(sleep)
-        x += 1
+    try:
+        return fn()
+    except:
+        if retries <= 0:
+            raise
+        sleep = (backoff_in_seconds * 2 ** retries +
+                random.uniform(0, 1))
+        logger.critical("Retrying in {} seconds".format(round(sleep)))
+        time.sleep(sleep)
+        retry_with_backoff(fn, retries - 1, backoff_in_seconds)

--- a/dags/utils/backoff.py
+++ b/dags/utils/backoff.py
@@ -4,7 +4,7 @@ import random
 
 logger = logging.getLogger()
 
-def retry_with_backoff(fn, retries = 6, backoff_in_seconds = 1):
+def retry_with_backoff(fn, retries = 10, backoff_in_seconds = 1):
     x = 0
     while True:
         try:
@@ -14,7 +14,6 @@ def retry_with_backoff(fn, retries = 6, backoff_in_seconds = 1):
                 raise
             sleep = (backoff_in_seconds * 2 ** x +
                     random.uniform(0, 1))
-            logger.critical(
-                "Retrying in {backoff} seconds".format(backoff=sleep))
+            logger.critical("Attempt {}, retrying in {} seconds".format(x, round(sleep)))
             time.sleep(sleep)
         x += 1

--- a/dags/utils/test_backoff.py
+++ b/dags/utils/test_backoff.py
@@ -11,6 +11,6 @@ def test_backoff_raises_exception(monkeypatch):
         retry_with_backoff(monkeypatch)
 
 def test_backoff_passes():
-    def mock_function():
-        return 0
-    assert 0 == retry_with_backoff(mock_function)
+    def mock_function(x):
+        return x
+    assert 8 == retry_with_backoff(lambda: mock_function(8))

--- a/dags/utils/test_backoff.py
+++ b/dags/utils/test_backoff.py
@@ -14,3 +14,5 @@ def test_backoff_passes():
     def mock_function(x):
         return x
     assert 8 == retry_with_backoff(lambda: mock_function(8))
+    assert "word" == retry_with_backoff(lambda: mock_function("word"))
+    assert None == retry_with_backoff(lambda: mock_function(None))

--- a/dags/utils/test_backoff.py
+++ b/dags/utils/test_backoff.py
@@ -1,17 +1,14 @@
 from backoff import retry_with_backoff
 import pytest
 
-import logging
-logger = logging.getLogger()
-
+# run this test with
+# pytest -s -p no:logging test_backoff.py
+# to see logging during backoff process
 def test_backoff_raises_exception(monkeypatch):
+    # skip actual sleep time
     monkeypatch.setattr("time.sleep", lambda x: None)
     with pytest.raises(Exception):
         retry_with_backoff(monkeypatch)
-
-def test_backoff_fails(monkeypatch):
-    monkeypatch.setattr("time.sleep", lambda x: None)
-    retry_with_backoff(monkeypatch)
 
 def test_backoff_passes():
     def mock_function():

--- a/dags/utils/test_backoff.py
+++ b/dags/utils/test_backoff.py
@@ -1,0 +1,16 @@
+from backoff import retry_with_backoff
+import pytest
+
+import logging
+logger = logging.getLogger(__name__)
+
+def test_backoff_raises_exception(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
+
+    with pytest.raises(Exception):
+        retry_with_backoff(monkeypatch)
+
+def test_backoff_passes():
+    def mock_function():
+        return 0
+    assert 0 == retry_with_backoff(mock_function)

--- a/dags/utils/test_backoff.py
+++ b/dags/utils/test_backoff.py
@@ -2,13 +2,16 @@ from backoff import retry_with_backoff
 import pytest
 
 import logging
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 def test_backoff_raises_exception(monkeypatch):
     monkeypatch.setattr("time.sleep", lambda x: None)
-
     with pytest.raises(Exception):
         retry_with_backoff(monkeypatch)
+
+def test_backoff_fails(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    retry_with_backoff(monkeypatch)
 
 def test_backoff_passes():
     def mock_function():


### PR DESCRIPTION
Implement exponential backoff when checking to see if the k8s job has been created from the cron job. 

Some info and best practices for [exponential backoff](https://cloud.google.com/iot/docs/how-tos/exponential-backoff)

[card](https://github.com/bcgov/cas-airflow/issues/139)