### PR TITLE
fix: airflow needs the default user, go back to creating it

### DIFF
--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -25,6 +25,15 @@ airflow:
   gid: 1002490000
   executor: KubernetesExecutor
 
+  defaultUser:
+    enabled: true
+    role: Admin
+    username: cas-airflow-admin
+    email: admin@example.com
+    firstName: admin
+    lastName: user
+    password: "$(DEFAULT_USER_PASS)"
+
   # This should match the mounting point of the cas-airflow-dynamic-dags-pvc PVC
   dynamicDagsPath: /opt/airflow/dags/dynamic
 
@@ -58,6 +67,9 @@ airflow:
 
   # Secrets for all airflow containers
   secret:
+    - envName: DEFAULT_USER_PASS
+      secretName: airflow-default-user-password
+      secretKey: default-user-pass
     - envName: PGPASS
       secretName: cas-airflow-patroni
       secretKey: password-superuser
@@ -111,6 +123,8 @@ airflow:
       limits:
         cpu: 500m
         memory: 2Gi
+    defaultUser:
+      enabled: true
 
   # Airflow scheduler settings
   scheduler:

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -25,15 +25,6 @@ airflow:
   gid: 1002490000
   executor: KubernetesExecutor
 
-  defaultUser:
-    enabled: true
-    role: Admin
-    username: cas-airflow-admin
-    email: admin@example.com
-    firstName: admin
-    lastName: user
-    password: "$(DEFAULT_USER_PASS)"
-
   # This should match the mounting point of the cas-airflow-dynamic-dags-pvc PVC
   dynamicDagsPath: /opt/airflow/dags/dynamic
 
@@ -125,6 +116,12 @@ airflow:
         memory: 2Gi
     defaultUser:
       enabled: true
+      role: Admin
+      username: cas-airflow-admin
+      email: admin@example.com
+      firstName: admin
+      lastName: user
+      password: "$(DEFAULT_USER_PASS)"
 
   # Airflow scheduler settings
   scheduler:


### PR DESCRIPTION
We removed the default user and credentials from airflow in favour of using Github auth. It turns out airflow needs that default user to exist, so we've added it back in.