### PR TITLE
chore: release - use airflow chart v1.9.0 and airflow v2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM apache/airflow:2.6.1
+FROM apache/airflow:2.5.3
 
 COPY --chown=airflow:root ./dags /opt/airflow/dags

--- a/helm/cas-airflow/Chart.yaml
+++ b/helm/cas-airflow/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cas-airflow
 type: application
-version: 1.2.0
-appVersion: 2.6.1 # The airflow version
+version: 2.0.0
+appVersion: 2.5.3 # The airflow version
 description: Helm chart to deploy cas' flavour of airflow, compatible with OpenShift 4. This chart uses the vanilla airflow chart and adds cas' own templates and values.
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:
@@ -12,7 +12,7 @@ keywords:
   - bcgov
 dependencies:
   - name: airflow
-    version: "1.7.0"
+    version: "1.9.0"
     repository: "https://airflow.apache.org/"
   - name: cas-postgres
     version: "0.8.3"

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -32,7 +32,7 @@ airflow:
   # Will be overridden by the git commit sha
   defaultAirflowTag: "to_override"
 
-  airflowVersion: "2.6.1"
+  airflowVersion: "2.5.3"
 
   # Enable RBAC (default on most clusters these days)
   rbac:
@@ -172,7 +172,7 @@ airflow:
     scheduler:
       min_file_process_interval: 30
 
-    kubernetes:
+    kubernetes_executor:
       run_as_user: "{{ .Values.uid }}"
       delete_worker_pods: "True"
 

--- a/run_local.sh
+++ b/run_local.sh
@@ -7,11 +7,11 @@ set -e
 export AIRFLOW_HOME=.
 export DYNAMIC_DAGS_PATH=./dags/dynamic
 
-AIRFLOW_VERSION=2.6.1
+AIRFLOW_VERSION=2.5.3
 PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
 # For example: 3.6
 CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
-# For example: https://raw.githubusercontent.com/apache/airflow/constraints-2.6.1/constraints-3.6.txt
+# For example: https://raw.githubusercontent.com/apache/airflow/constraints-2.5.3/constraints-3.6.txt
 pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 pip install apache-airflow['cncf.kubernetes']
 


### PR DESCRIPTION
BREAKING CHANGE: airflow 2.5.0 renames kubernetes to kubernetes_executor in the config