### PR TITLE
Chore: release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,11 @@ jobs:
           helm repo add cas-postgres https://bcgov.github.io/cas-postgres/
           helm repo add apache-airflow "https://airflow.apache.org/"
 
+      - name: Update chart dependencies
+        working-directory: ./helm/cas-airflow
+        run: |
+          helm dep up
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1
         with:

--- a/docs/downgrading-airflow.md
+++ b/docs/downgrading-airflow.md
@@ -2,7 +2,11 @@
 Sometimes after deploying a newer version of Airflow, we need to revert back to an older version. Simply changing the version in our helm charts and deploy scripts is not enough because Airflow uses Alembic as a database migration tool. Alembic keeps track of IDs that track the changes to the schema for each version. When trying to downgrade versions, the migration will fail because it's expecting an ID after the current migration ID. This can cause the downgrade to fail because the database can't get its schema back into the desired state and will throw an error like `no revision found with id 123456`
 
 ## Steps to downgrade
-- Update the Airflow version to the target version dockerfile, run_local.sh, Chart.yaml and values.yaml
+- Update the Airflow version to the target version in:
+  -  Dockerfile
+  -  run_local.sh
+  -  Chart.yaml
+  -  values.yaml
 - Before deploying the changes to openshift:
   - From the webserver pod's terminal run: `airflow db downgrade --to-version=<target version>`
   - This will revert the database schema to align with the target downgraded version of airflow

--- a/docs/downgrading-airflow.md
+++ b/docs/downgrading-airflow.md
@@ -1,0 +1,9 @@
+# Downgrading Airflow Version
+Sometimes after deploying a newer version of Airflow, we need to revert back to an older version. Simply changing the version in our helm charts and deploy scripts is not enough because Airflow uses Alembic as a database migration tool. Alembic keeps track of IDs that track the changes to the schema for each version. When trying to downgrade versions, the migration will fail because it's expecting an ID after the current migration ID. This can cause the downgrade to fail because the database can't get its schema back into the desired state and will throw an error like `no revision found with id 123456`
+
+## Steps to downgrade
+- Update the Airflow version to the target version dockerfile, run_local.sh, Chart.yaml and values.yaml
+- Before deploying the changes to openshift:
+  - From the webserver pod's terminal run: `airflow db downgrade --to-version=<target version>`
+  - This will revert the database schema to align with the target downgraded version of airflow
+- Deploy the changes

--- a/helm/cas-airflow/Chart.lock
+++ b/helm/cas-airflow/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.9.0
 - name: cas-postgres
   repository: https://bcgov.github.io/cas-postgres/
-  version: 0.8.3
-digest: sha256:1171bb33092c62942a92d8fa0872bc5bbff60fbf09a7008ff1637b95a3b9815d
-generated: "2023-05-19T09:11:24.041062011-07:00"
+  version: 0.8.4
+digest: sha256:295f6820703ed656f7f27e76edc8fe133b6566aa06f5836d9c9c89dfe624ff88
+generated: "2023-05-23T16:19:10.676994395-07:00"

--- a/helm/cas-airflow/Chart.yaml
+++ b/helm/cas-airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cas-airflow
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 2.5.3 # The airflow version
 description: Helm chart to deploy cas' flavour of airflow, compatible with OpenShift 4. This chart uses the vanilla airflow chart and adds cas' own templates and values.
 icon: https://www.astronomer.io/static/airflowNewA.png
@@ -15,5 +15,5 @@ dependencies:
     version: "1.9.0"
     repository: "https://airflow.apache.org/"
   - name: cas-postgres
-    version: "0.8.3"
+    version: "0.8.4"
     repository: https://bcgov.github.io/cas-postgres/

--- a/helm/cas-airflow/values-dev.yaml
+++ b/helm/cas-airflow/values-dev.yaml
@@ -8,6 +8,8 @@ airflow:
   config:
     logging:
       remote_base_log_folder: gs://0fad32-dev-airflow-logs
+    smtp:
+      smtp_mail_from: cas-airflow-dev@gov.bc.ca
 
   workers:
     extraVolumeMounts:

--- a/helm/cas-airflow/values-prod.yaml
+++ b/helm/cas-airflow/values-prod.yaml
@@ -8,6 +8,8 @@ airflow:
   config:
     logging:
       remote_base_log_folder: gs://0fad32-prod-airflow-logs
+    smtp:
+      smtp_mail_from: cas-airflow-prod@gov.bc.ca
 
   workers:
     extraVolumeMounts:

--- a/helm/cas-airflow/values-test.yaml
+++ b/helm/cas-airflow/values-test.yaml
@@ -8,6 +8,8 @@ airflow:
   config:
     logging:
       remote_base_log_folder: gs://0fad32-test-airflow-logs
+    smtp:
+      smtp_mail_from: cas-airflow-test@gov.bc.ca
 
   workers:
     extraVolumeMounts:


### PR DESCRIPTION
- updated gh action to run `helm dep up` before releasing
- updated smtp settings in values-dev/test/prod so airflow shows which environment it's emailing from
- added documentation on downgrading to an earlier airflow version
- updated chart.yaml to use the latest cas-postgres chart (remove deprecated k8s api)