### PR TITLE
Chore/database migration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
           context: .
           dockerfile_path: Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          chart_version: 2.0.20
+          chart_version: 2.1.0
           is_chart_release: true
   cas-airflow-dag-trigger-build:
     needs: [release]

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,7 +10,10 @@ helm dep up ./helm/cas-airflow
 helm repo add cas-postgres https://bcgov.github.io/cas-postgres/
 helm repo update
 
-helm upgrade --install --values ./helm/cas-airflow-postgres-cluster/values.yaml cas-airflow-db cas-postgres/cas-postgres-cluster
+helm upgrade --install \
+  -f ./helm/cas-airflow-postgres-cluster/values.yaml \
+  -f "./helm/cas-airflow/values-$ENVIRONMENT.yaml" \
+  cas-airflow-db cas-postgres/cas-postgres-cluster
 
 helm upgrade --install --timeout 900s \
   --namespace "$AIRFLOW_NAMESPACE_PREFIX-$ENVIRONMENT" \

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 git_sha1=$(git rev-parse HEAD)
 
 helm dep up ./helm/cas-airflow
+helm repo add cas-postgres https://bcgov.github.io/cas-postgres/
+helm repo update
+
+helm upgrade --install --values ./helm/cas-airflow-postgres-cluster/values.yaml cas-airflow-db cas-postgres/cas-postgres-cluster
+
 helm upgrade --install --timeout 900s \
   --namespace "$AIRFLOW_NAMESPACE_PREFIX-$ENVIRONMENT" \
   -f ./helm/cas-airflow/values.yaml \

--- a/helm/cas-airflow-postgres-cluster/values-dev.yaml
+++ b/helm/cas-airflow-postgres-cluster/values-dev.yaml
@@ -1,0 +1,1 @@
+environment: dev

--- a/helm/cas-airflow-postgres-cluster/values-prod.yaml
+++ b/helm/cas-airflow-postgres-cluster/values-prod.yaml
@@ -1,0 +1,1 @@
+environment: prod

--- a/helm/cas-airflow-postgres-cluster/values-test.yaml
+++ b/helm/cas-airflow-postgres-cluster/values-test.yaml
@@ -1,0 +1,1 @@
+environment: test

--- a/helm/cas-airflow-postgres-cluster/values.yaml
+++ b/helm/cas-airflow-postgres-cluster/values.yaml
@@ -4,6 +4,7 @@
 environment: ~
 
 postgresCluster:
+  postgresVersion: 17
   postgres:
     replicaCount: 3
   pgbouncer:

--- a/helm/cas-airflow-postgres-cluster/values.yaml
+++ b/helm/cas-airflow-postgres-cluster/values.yaml
@@ -1,0 +1,41 @@
+# Values file to be passed to a deployment of https://github.com/bcgov/cas-postgres/tree/develop/helm/cas-postgres-cluster
+
+# dev, test, prod
+environment: ~
+
+postgresCluster:
+  postgres:
+    replicaCount: 3
+  pgbouncer:
+    replicaCount: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+  # The "users" value(s) is passed to the crunch postgres operator to create the database.
+  # See http://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/user-management
+  users:
+    - name: postgres
+      options: "SUPERUSER"
+    - name: airflow
+      databases:
+        - airflow
+        - postgres
+
+gcsBackups:
+  enable: true
+  # Needs to match the "namespace_apps" value in the terraform provisioning chart.
+  # example syntax: bucketName
+  bucketName: af-pgo-backups
+
+terraform-bucket-provision:
+  terraform:
+    # example syntax: '["bucketName"]'
+    namespace_apps: '["af-pgo-backups"]'
+    # !important: unique for the deployment
+    workspace: airflow-pgo
+
+# To configure a KNP allowing external access, for metabase for example
+external-access:
+  enabled: false

--- a/helm/cas-airflow-postgres-cluster/values.yaml
+++ b/helm/cas-airflow-postgres-cluster/values.yaml
@@ -19,9 +19,10 @@ postgresCluster:
   users:
     - name: postgres
       options: "SUPERUSER"
+      databases:
+        - postgres
     - name: airflow
       databases:
-        - airflow
         - postgres
 
 gcsBackups:

--- a/helm/cas-airflow/Chart.lock
+++ b/helm/cas-airflow/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: terraform-bucket-provision
   repository: https://bcgov.github.io/cas-pipeline/
   version: 0.1.3
-digest: sha256:fa547b34056cf2431a0354054e48b4efeefc39cd74be257e4e6a64b14cc9174e
-generated: "2024-11-15T13:11:12.776004708-08:00"
+- name: patroni-migration
+  repository: https://bcgov.github.io/cas-postgres/
+  version: 1.0.1
+digest: sha256:164d57773acfb1c55c545e2bede23068136614ae2a2a52b9bf8d26bacd375914
+generated: "2025-05-13T08:52:20.688824737-06:00"

--- a/helm/cas-airflow/Chart.yaml
+++ b/helm/cas-airflow/Chart.yaml
@@ -20,3 +20,6 @@ dependencies:
   - name: terraform-bucket-provision
     version: "0.1.3"
     repository: https://bcgov.github.io/cas-pipeline/
+  - name: patroni-migration
+    version: 1.0.1
+    repository: https://bcgov.github.io/cas-postgres/

--- a/helm/cas-airflow/Chart.yaml
+++ b/helm/cas-airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cas-airflow
 type: application
-version: 2.0.20 # Changing this requires updating the image tag in .github/workflows/release.yaml
+version: 2.1.0 # Changing this requires updating the image tag in .github/workflows/release.yaml
 appVersion: 2.10.5 # The airflow version
 description: Helm chart to deploy cas' flavour of airflow, compatible with OpenShift 4. This chart uses the vanilla airflow chart and adds cas' own templates and values.
 icon: https://www.astronomer.io/static/airflowNewA.png

--- a/helm/cas-airflow/templates/networkPolicy/postgres-cluster-access.yaml
+++ b/helm/cas-airflow/templates/networkPolicy/postgres-cluster-access.yaml
@@ -1,0 +1,17 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "cas-airflow.fullname" . }}-postgres-cluster-access
+  labels: {{ include "cas-airflow.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Values.database.clusterReleaseName }}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              release: {{ include "cas-airflow.name" . }}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ include "cas-airflow.name" . }}

--- a/helm/cas-airflow/templates/secrets/metadata.yaml
+++ b/helm/cas-airflow/templates/secrets/metadata.yaml
@@ -1,8 +1,6 @@
 ################################
 ## Airflow Metadata Secret
 #################################
-{{- $postgresHost := (printf "%s-%s.%s.svc.cluster.local" .Release.Name "patroni" .Release.Namespace) }}
-{{- $host := $postgresHost }}
 {{- $port := .Values.airflow.data.metadataConnection.port | toString }}
 {{- $database := .Values.airflow.data.metadataConnection.db }}
 
@@ -16,4 +14,4 @@ metadata:
 {{ include "cas-airflow.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?sslmode=%s" .Values.airflow.data.metadataConnection.user .Values.airflow.data.metadataConnection.pass $host $port $database .Values.airflow.data.metadataConnection.sslmode) | b64enc | quote }}
+  connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?sslmode=%s" .Values.airflow.data.metadataConnection.user .Values.airflow.data.metadataConnection.pass .Values.airflow.data.metadataConnection.host $port $database .Values.airflow.data.metadataConnection.sslmode) | b64enc | quote }}

--- a/helm/cas-airflow/templates/secrets/metadata.yaml
+++ b/helm/cas-airflow/templates/secrets/metadata.yaml
@@ -1,8 +1,8 @@
 ################################
 ## Airflow Metadata Secret
 #################################
-{{- $port := .Values.airflow.data.metadataConnection.port | toString }}
-{{- $database := .Values.airflow.data.metadataConnection.db }}
+## Uses the PGBOUNCER_URI environment variable to connect to the database, which ensures characters are URI encoded
+#################################
 
 kind: Secret
 apiVersion: v1
@@ -14,4 +14,4 @@ metadata:
 {{ include "cas-airflow.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?sslmode=%s" .Values.airflow.data.metadataConnection.user .Values.airflow.data.metadataConnection.pass .Values.airflow.data.metadataConnection.host $port $database .Values.airflow.data.metadataConnection.sslmode) | b64enc | quote }}
+  connection: {{ (printf "$PGBOUNCER_URI?sslmode=%s"  .Values.airflow.data.metadataConnection.sslmode) | b64enc | quote }}

--- a/helm/cas-airflow/templates/secrets/result-backend.yaml
+++ b/helm/cas-airflow/templates/secrets/result-backend.yaml
@@ -1,6 +1,8 @@
 ################################
 ## Airflow Result Backend Secret
 #################################
+## Uses the PGBOUNCER_URI environment variable to connect to the database, which ensures characters are URI encoded
+#################################
 kind: Secret
 apiVersion: v1
 metadata:
@@ -11,4 +13,4 @@ metadata:
 {{ include "cas-airflow.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  connection: {{ (printf "db+postgresql://%s:%s@%s:%s/%s?sslmode=%s" .Values.airflow.data.resultBackendConnection.user .Values.airflow.data.resultBackendConnection.pass .Values.airflow.data.resultBackendConnection.host (.Values.airflow.data.resultBackendConnection.port | toString) .Values.airflow.data.resultBackendConnection.db .Values.airflow.data.resultBackendConnection.sslmode) | b64enc | quote }}
+  connection: {{ (printf "db+$PGBOUNCER_URI?sslmode=%s"  .Values.airflow.data.resultBackendConnection.sslmode) | b64enc | quote }}

--- a/helm/cas-airflow/templates/secrets/result-backend.yaml
+++ b/helm/cas-airflow/templates/secrets/result-backend.yaml
@@ -1,7 +1,6 @@
 ################################
 ## Airflow Result Backend Secret
 #################################
-{{- $host := (printf "%s-%s" .Release.Name "patroni") }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -12,4 +11,4 @@ metadata:
 {{ include "cas-airflow.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  connection: {{ (printf "db+postgresql://%s:%s@%s:%s/%s?sslmode=%s" .Values.airflow.data.resultBackendConnection.user .Values.airflow.data.resultBackendConnection.pass $host (.Values.airflow.data.resultBackendConnection.port | toString) .Values.airflow.data.resultBackendConnection.db .Values.airflow.data.resultBackendConnection.sslmode) | b64enc | quote }}
+  connection: {{ (printf "db+postgresql://%s:%s@%s:%s/%s?sslmode=%s" .Values.airflow.data.resultBackendConnection.user .Values.airflow.data.resultBackendConnection.pass .Values.airflow.data.resultBackendConnection.host (.Values.airflow.data.resultBackendConnection.port | toString) .Values.airflow.data.resultBackendConnection.db .Values.airflow.data.resultBackendConnection.sslmode) | b64enc | quote }}

--- a/helm/cas-airflow/values-dev.yaml
+++ b/helm/cas-airflow/values-dev.yaml
@@ -48,3 +48,7 @@ cas-postgres:
   namespace: 0fad32-dev
   gcs:
     bucketSuffix: airflow-backups
+
+patroni-migration:
+  from:
+    host: cas-airflow-patroni.0fad32-dev.svc.cluster.local

--- a/helm/cas-airflow/values-prod.yaml
+++ b/helm/cas-airflow/values-prod.yaml
@@ -47,3 +47,7 @@ cas-postgres:
   namespace: 0fad32-prod
   gcs:
     bucketSuffix: airflow-backups
+
+patroni-migration:
+  from:
+    host: cas-airflow-patroni.0fad32-prod.svc.cluster.local

--- a/helm/cas-airflow/values-test.yaml
+++ b/helm/cas-airflow/values-test.yaml
@@ -47,3 +47,7 @@ cas-postgres:
   namespace: 0fad32-test
   gcs:
     bucketSuffix: airflow-backups
+
+patroni-migration:
+  from:
+    host: cas-airflow-patroni.0fad32-test.svc.cluster.local

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -10,6 +10,9 @@ dynamicDagStorage:
 # The name of the ArtifactoryServiceAccount object created in the cas-provision chart
 artifactoryServiceAccount: cas-artifact-download
 
+database:
+  clusterReleaseName: cas-airflow-db
+
 # The values we need to override from the airflow defaults
 airflow:
   uid: 1002490000
@@ -53,7 +56,7 @@ airflow:
       secretName: airflow-default-user-password
       secretKey: default-user-pass
     - envName: PGPASS
-      secretName: cas-airflow-patroni
+      secretName: cas-airflow-db-cas-postgres-cluster-pguser-airflow
       secretKey: password-superuser
     - envName: AIRFLOW_NAMESPACE
       secretName: cas-namespaces
@@ -80,19 +83,19 @@ airflow:
   # Airflow database config
   data:
     metadataSecretName: cas-airflow-metadata
-    resultBackendSecretName: cas-airflow-metadata
+    resultBackendSecretName: cas-airflow-result-backend
 
     metadataConnection:
-      user: postgres
+      user: airflow
       pass: $PGPASS
       host: ~
       port: 5432
       db: postgres
       sslmode: disable
     resultBackendConnection:
-      user: postgres
+      user: airflow
       pass: $PGPASS
-      host: cas-airflow-patroni
+      host: cas-airflow-db-cas-postgres-cluster
       port: 5432
       db: postgres
       sslmode: disable
@@ -233,3 +236,37 @@ devops:
 terraform-bucket-provision:
   terraform:
     namespace_apps: '["airflow-backups", "airflow-logs"]'
+
+patroni-migration:
+  migrationJob:
+    image: postgres
+    tag: 15
+
+  deployment:
+    name: cas-airflow-scheduler
+    sourceReleaseName: cas-airflow
+    targetReleaseName: cas-airflow-db
+    originalReplicaCount: 3
+
+  from:
+    # Assuming all database information will be in the same secret
+    # Pass either the secret's key or the specific value
+    secretName: cas-airflow-patroni
+    hostSecretKey: ~
+    host: ~ # cas-metabase-patroni.9212c9-dev.svc.cluster.local
+    passwordSecretKey: password-superuser
+    password: ~
+    portSecretKey: ~
+    port: 5432
+    userSecretKey: ~
+    user: postgres
+
+    # The name of the database to migrate
+    db: postgres
+
+  to:
+    # This is necessarily a PGO deployment
+    # superuser to migrate roles
+    superuserSecretName: cas-airflow-db-cas-postgres-cluster-pguser-postgres
+    # new owner of database to run own the migrated database
+    appuserSecretName: cas-airflow-db-cas-postgres-cluster-pguser-airflow

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -58,6 +58,9 @@ airflow:
     - envName: PGPASS
       secretName: cas-airflow-db-cas-postgres-cluster-pguser-airflow
       secretKey: password
+    - envName: HOST
+      secretName: cas-airflow-db-cas-postgres-cluster-pguser-airflow
+      secretKey: pgbouncer-host
     - envName: AIRFLOW_NAMESPACE
       secretName: cas-namespaces
       secretKey: airflow-namespace
@@ -88,14 +91,14 @@ airflow:
     metadataConnection:
       user: airflow
       pass: $PGPASS
-      host: ~
+      host: $HOST
       port: 5432
       db: postgres
       sslmode: disable
     resultBackendConnection:
       user: airflow
       pass: $PGPASS
-      host: cas-airflow-db-cas-postgres-cluster
+      host: $HOST
       port: 5432
       db: postgres
       sslmode: disable

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -61,6 +61,9 @@ airflow:
     - envName: HOST
       secretName: cas-airflow-db-cas-postgres-cluster-pguser-airflow
       secretKey: pgbouncer-host
+    - envName: PGBOUNCER_URI
+      secretName: cas-airflow-db-cas-postgres-cluster-pguser-airflow
+      secretKey: pgbouncer-uri
     - envName: AIRFLOW_NAMESPACE
       secretName: cas-namespaces
       secretKey: airflow-namespace

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -57,7 +57,7 @@ airflow:
       secretKey: default-user-pass
     - envName: PGPASS
       secretName: cas-airflow-db-cas-postgres-cluster-pguser-airflow
-      secretKey: password-superuser
+      secretKey: password
     - envName: AIRFLOW_NAMESPACE
       secretName: cas-namespaces
       secretKey: airflow-namespace

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -240,7 +240,7 @@ terraform-bucket-provision:
 patroni-migration:
   migrationJob:
     image: postgres
-    tag: 15
+    tag: 17
 
   deployment:
     name: cas-airflow-scheduler


### PR DESCRIPTION
Addresses #189. Migrates the DB to the Crunchy Operator.

## Changes 🚧

- Added deployment values for `cas-postgres/cas-postgres-cluster` Crunchy chart.
- Updated deployment script to include new chart.
- Added migration from old DB to new DB.
- Updated Airflow chart to look for new DB.
- Added network policy for new DB.

## Run notes (from dev) 🏃 

- Needed to grant permissions to the new user for the tables in the new cluster. See the [Airflow Docs](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html#setting-up-a-postgresql-database)