### PR TITLE
Chore/224 update airflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
           context: .
           dockerfile_path: Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          chart_version: 3.1.0
+          chart_version: 3.1.1
           is_chart_release: true
   cas-airflow-dag-trigger-build:
     needs: [release]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:3.1.2
+FROM apache/airflow:3.1.8
 
 # Install the standard providers for Airflow 2 -- can be removed when we upgrade to Airflow 3
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" apache-airflow-providers-standard

--- a/helm/cas-airflow/Chart.lock
+++ b/helm/cas-airflow/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: airflow
   repository: https://airflow.apache.org/
-  version: 1.18.0
+  version: 1.19.0
 - name: terraform-bucket-provision
   repository: https://bcgov.github.io/cas-pipeline/
   version: 0.1.3
-digest: sha256:98240d16977d7eabf4897ef0be279c4e85c7f8ae6ec389376b7c28212d513798
-generated: "2025-09-09T14:12:54.100483261-06:00"
+digest: sha256:325c0d60c55e7a2e792aa30f238399e65a2015e26ba993f85037c95910a316a0
+generated: "2026-03-19T14:03:21.67381925-06:00"

--- a/helm/cas-airflow/Chart.yaml
+++ b/helm/cas-airflow/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - bcgov
 dependencies:
   - name: airflow
-    version: "1.18.0"
+    version: "1.19.0"
     repository: "https://airflow.apache.org/"
   - name: terraform-bucket-provision
     version: "0.1.3"

--- a/helm/cas-airflow/Chart.yaml
+++ b/helm/cas-airflow/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cas-airflow
 type: application
-version: 3.1.0 # Changing this requires updating the image tag in .github/workflows/release.yaml
-appVersion: 3.1.2 # The airflow version
+version: 3.1.1 # Changing this requires updating the image tag in .github/workflows/release.yaml
+appVersion: 3.1.8 # The airflow version
 description: Helm chart to deploy cas' flavour of airflow, compatible with OpenShift 4. This chart uses the vanilla airflow chart and adds cas' own templates and values.
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -26,7 +26,7 @@ airflow:
   # Will be overridden by the git commit sha
   defaultAirflowTag: "to_override"
 
-  airflowVersion: "3.1.2"
+  airflowVersion: "3.1.8"
 
   # Enable RBAC (default on most clusters these days)
   rbac:

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -116,29 +116,19 @@ airflow:
       requests:
         cpu: 50m
         memory: 400Mi
-    defaultUser:
-      enabled: true
-      role: Admin
-      username: cas-airflow-admin
-      email: admin@example.com
-      firstName: admin
-      lastName: user
-      password: "$(DEFAULT_USER_PASS)"
     startupProbe:
       timeoutSeconds: 120
       periodSeconds: 60
 
-  # createUserJob.args param uses the webserver.defaultUser values as of Airflow 3.1.2,
-  # So we need to override them here instead of in apiServer.defaultUser
-  webserver:
-    defaultUser:
-      enabled: true
-      role: Admin
-      username: cas-airflow-admin
-      email: admin@example.com
-      firstName: admin
-      lastName: user
-      password: "$(DEFAULT_USER_PASS)"
+  jobs:
+    createUserJob:
+      defaultUser:
+        email: admin@example.com
+        firstName: admin
+        lastName: user
+        password: "$(DEFAULT_USER_PASS)"
+        role: Admin
+        username: cas-airflow-admin
 
   # Airflow scheduler settings
   scheduler:

--- a/run_local.sh
+++ b/run_local.sh
@@ -7,7 +7,7 @@ set -e
 export AIRFLOW_HOME=.
 export DYNAMIC_DAGS_PATH=./dags/dynamic
 
-AIRFLOW_VERSION=3.1.2
+AIRFLOW_VERSION=3.1.8
 PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
 # For example: 3.6
 CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"


### PR DESCRIPTION
Addresses #224. Updates Airflow to version 3.1.8.

## Changes 🚧

- Move default user creation into job portion of values (see the [Airflow release notes for reasoning](https://airflow.apache.org/docs/helm-chart/1.19.0/release_notes.html#options-to-create-a-default-user-have-been-moved-under-the-createuserjob-section))
- update all 3.1.2 instances to 3.1.8
