### PR TITLE
fix: incorrect parameter path for createUserJob

### DIFF
--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -120,15 +120,14 @@ airflow:
       timeoutSeconds: 120
       periodSeconds: 60
 
-  jobs:
-    createUserJob:
-      defaultUser:
-        email: admin@example.com
-        firstName: admin
-        lastName: user
-        password: "$(DEFAULT_USER_PASS)"
-        role: Admin
-        username: cas-airflow-admin
+  createUserJob:
+    defaultUser:
+      email: admin@example.com
+      firstName: admin
+      lastName: user
+      password: "$(DEFAULT_USER_PASS)"
+      role: Admin
+      username: cas-airflow-admin
 
   # Airflow scheduler settings
   scheduler:


### PR DESCRIPTION
Fixed the parameter path for the createUserJob. Per reread of https://airflow.apache.org/docs/helm-chart/stable/parameters-ref.html#jobs, parameters listed are _absolute_, not `relative to the subheading/category`. 