### PR TITLE
Chore/update to 3.2.2

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -71,4 +71,3 @@ runs:
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
           context: .
           dockerfile_path: Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          chart_version: 3.1.1
+          chart_version: 3.1.2
           is_chart_release: true
   cas-airflow-dag-trigger-build:
     needs: [release]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,5 @@ repos:
       - id: trailing-whitespace
       - id: check-json
       - id: check-yaml
+        exclude: ^helm/.*/templates/
       - id: end-of-file-fixer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
 FROM apache/airflow:3.2.2
 
-# Install the standard providers for Airflow 2 -- can be removed when we upgrade to Airflow 3
-RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" apache-airflow-providers-standard
-
 COPY --chown=airflow:root ./dags /opt/airflow/dags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:3.1.8
+FROM apache/airflow:3.2.2
 
 # Install the standard providers for Airflow 2 -- can be removed when we upgrade to Airflow 3
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" apache-airflow-providers-standard

--- a/dag-trigger/Dockerfile
+++ b/dag-trigger/Dockerfile
@@ -5,4 +5,3 @@ RUN apk add --no-cache --upgrade bash jq curl
 COPY ./airflow-dag-trigger.sh /
 
 RUN chmod +x airflow-dag-trigger.sh
-

--- a/dags/fetch_and_save_dag_from_github.py
+++ b/dags/fetch_and_save_dag_from_github.py
@@ -49,7 +49,7 @@ def fetch_and_save_dag_from_github(
     @task()
     def wait_task(seconds):
         time.sleep(seconds)
-        
+
 
     get_file(org, repo, ref, path) >> wait_task(wait_seconds*2)
 

--- a/helm/cas-airflow-dag-trigger/templates/_helpers.tpl
+++ b/helm/cas-airflow-dag-trigger/templates/_helpers.tpl
@@ -76,8 +76,8 @@ Gets the suffix of the namespace. (-dev, -tools, ... )
 {{- (split "-" .Release.Namespace)._1 | trim -}}
 {{- end }}
 
-{{/* 
-Looks up the artifactory service account and 
+{{/*
+Looks up the artifactory service account and
 generates the image pull secret
 */}}
 {{- define "cas-airflow-dag-trigger.imagePullSecrets" }}

--- a/helm/cas-airflow/Chart.lock
+++ b/helm/cas-airflow/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: airflow
   repository: https://airflow.apache.org/
-  version: 1.19.0
+  version: 1.21.0
 - name: terraform-bucket-provision
   repository: https://bcgov.github.io/cas-pipeline/
   version: 0.1.3
-digest: sha256:325c0d60c55e7a2e792aa30f238399e65a2015e26ba993f85037c95910a316a0
-generated: "2026-03-19T14:03:21.67381925-06:00"
+digest: sha256:4648e394c7733f8d2439fe28aab33649f48a57b509d517e03a9aea16d976d6e1
+generated: "2026-06-01T13:02:45.570505632-06:00"

--- a/helm/cas-airflow/Chart.yaml
+++ b/helm/cas-airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cas-airflow
 type: application
-version: 3.1.1 # Changing this requires updating the image tag in .github/workflows/release.yaml
+version: 3.1.2 # Changing this requires updating the image tag in .github/workflows/release.yaml
 appVersion: 3.2.2 # The airflow version
 description: Helm chart to deploy cas' flavour of airflow, compatible with OpenShift 4. This chart uses the vanilla airflow chart and adds cas' own templates and values.
 icon: https://www.astronomer.io/static/airflowNewA.png

--- a/helm/cas-airflow/Chart.yaml
+++ b/helm/cas-airflow/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - bcgov
 dependencies:
   - name: airflow
-    version: "1.19.0"
+    version: "1.21.0"
     repository: "https://airflow.apache.org/"
   - name: terraform-bucket-provision
     version: "0.1.3"

--- a/helm/cas-airflow/Chart.yaml
+++ b/helm/cas-airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cas-airflow
 type: application
 version: 3.1.1 # Changing this requires updating the image tag in .github/workflows/release.yaml
-appVersion: 3.1.8 # The airflow version
+appVersion: 3.2.2 # The airflow version
 description: Helm chart to deploy cas' flavour of airflow, compatible with OpenShift 4. This chart uses the vanilla airflow chart and adds cas' own templates and values.
 icon: https://www.astronomer.io/static/airflowNewA.png
 keywords:

--- a/helm/cas-airflow/templates/_helpers.tpl
+++ b/helm/cas-airflow/templates/_helpers.tpl
@@ -60,8 +60,8 @@ Gets the suffix of the namespace. (-dev, -tools, ... )
 {{- (split "-" .Release.Namespace)._1 | trim -}}
 {{- end }}
 
-{{/* 
-Looks up the artifactory service account and 
+{{/*
+Looks up the artifactory service account and
 generates the image pull secret
 */}}
 {{- define "cas-airflow.imagePullSecrets" }}

--- a/helm/cas-airflow/templates/routes/route.yaml
+++ b/helm/cas-airflow/templates/routes/route.yaml
@@ -2,7 +2,7 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: {{ .Release.Name }}-web
-  labels: 
+  labels:
 {{ include "cas-airflow.labels" . | nindent 4 }}
 spec:
   host: {{ .Release.Name }}-{{ include "cas-airflow.namespaceSuffix" . }}.{{ .Values.route.clusterDomain }}

--- a/helm/cas-airflow/values-dev.yaml
+++ b/helm/cas-airflow/values-dev.yaml
@@ -12,19 +12,20 @@ airflow:
       smtp_mail_from: cas-airflow-dev@gov.bc.ca
 
   workers:
-    extraVolumeMounts:
-      - name: gcs-credentials
-        mountPath: /gcs
-        readOnly: true
-      - name: cas-airflow-dynamic-dags
-        mountPath: /opt/airflow/dags/dynamic
-    extraVolumes:
-      - name: gcs-credentials
-        secret:
-          secretName: gcp-0fad32-dev-airflow-logs-service-account-key
-      - name: cas-airflow-dynamic-dags
-        persistentVolumeClaim:
-          claimName: cas-airflow-dynamic-dags-pvc
+    kubernetes:
+      extraVolumeMounts:
+        - name: gcs-credentials
+          mountPath: /gcs
+          readOnly: true
+        - name: cas-airflow-dynamic-dags
+          mountPath: /opt/airflow/dags/dynamic
+      extraVolumes:
+        - name: gcs-credentials
+          secret:
+            secretName: gcp-0fad32-dev-airflow-logs-service-account-key
+        - name: cas-airflow-dynamic-dags
+          persistentVolumeClaim:
+            claimName: cas-airflow-dynamic-dags-pvc
 
   apiServer:
     replicas: 2

--- a/helm/cas-airflow/values-prod.yaml
+++ b/helm/cas-airflow/values-prod.yaml
@@ -12,19 +12,20 @@ airflow:
       smtp_mail_from: cas-airflow-prod@gov.bc.ca
 
   workers:
-    extraVolumeMounts:
-      - name: gcs-credentials
-        mountPath: /gcs
-        readOnly: true
-      - name: cas-airflow-dynamic-dags
-        mountPath: /opt/airflow/dags/dynamic
-    extraVolumes:
-      - name: gcs-credentials
-        secret:
-          secretName: gcp-0fad32-prod-airflow-logs-service-account-key
-      - name: cas-airflow-dynamic-dags
-        persistentVolumeClaim:
-          claimName: cas-airflow-dynamic-dags-pvc
+    kubernetes:
+      extraVolumeMounts:
+        - name: gcs-credentials
+          mountPath: /gcs
+          readOnly: true
+        - name: cas-airflow-dynamic-dags
+          mountPath: /opt/airflow/dags/dynamic
+      extraVolumes:
+        - name: gcs-credentials
+          secret:
+            secretName: gcp-0fad32-prod-airflow-logs-service-account-key
+        - name: cas-airflow-dynamic-dags
+          persistentVolumeClaim:
+            claimName: cas-airflow-dynamic-dags-pvc
 
   apiServer:
     extraVolumeMounts:

--- a/helm/cas-airflow/values-test.yaml
+++ b/helm/cas-airflow/values-test.yaml
@@ -12,19 +12,20 @@ airflow:
       smtp_mail_from: cas-airflow-test@gov.bc.ca
 
   workers:
-    extraVolumeMounts:
-      - name: gcs-credentials
-        mountPath: /gcs
-        readOnly: true
-      - name: cas-airflow-dynamic-dags
-        mountPath: /opt/airflow/dags/dynamic
-    extraVolumes:
-      - name: gcs-credentials
-        secret:
-          secretName: gcp-0fad32-test-airflow-logs-service-account-key
-      - name: cas-airflow-dynamic-dags
-        persistentVolumeClaim:
-          claimName: cas-airflow-dynamic-dags-pvc
+    kubernetes:
+      extraVolumeMounts:
+        - name: gcs-credentials
+          mountPath: /gcs
+          readOnly: true
+        - name: cas-airflow-dynamic-dags
+          mountPath: /opt/airflow/dags/dynamic
+      extraVolumes:
+        - name: gcs-credentials
+          secret:
+            secretName: gcp-0fad32-test-airflow-logs-service-account-key
+        - name: cas-airflow-dynamic-dags
+          persistentVolumeClaim:
+            claimName: cas-airflow-dynamic-dags-pvc
 
   apiServer:
     extraVolumeMounts:

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -26,7 +26,7 @@ airflow:
   # Will be overridden by the git commit sha
   defaultAirflowTag: "to_override"
 
-  airflowVersion: "3.1.8"
+  airflowVersion: "3.2.2"
 
   # Enable RBAC (default on most clusters these days)
   rbac:

--- a/helm/cas-airflow/values.yaml
+++ b/helm/cas-airflow/values.yaml
@@ -13,6 +13,13 @@ artifactoryServiceAccount: cas-artifact-download
 database:
   clusterReleaseName: cas-airflow-db
 
+namespaces:
+  airflow: ~
+  ggircs: ~
+  ciip: ~
+  cif: ~
+  obps: ~
+
 # The values we need to override from the airflow defaults
 airflow:
   uid: 1002490000

--- a/run_local.sh
+++ b/run_local.sh
@@ -7,7 +7,7 @@ set -e
 export AIRFLOW_HOME=.
 export DYNAMIC_DAGS_PATH=./dags/dynamic
 
-AIRFLOW_VERSION=3.1.8
+AIRFLOW_VERSION=3.2.2
 PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
 # For example: 3.6
 CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"


### PR DESCRIPTION
Addresses #227 . Updates Airflow to version 3.2.2.

## Changes 🚧

- Moved general worker configs to `workers.kubernetes` subsection (see the [Airflow chart release notes](https://github.com/apache/airflow/releases/tag/helm-chart%2F1.21.0))
- update all 3.1.8 instances to 3.2.2
- Updated helm chart to 1.21.0
