### PR TITLE
fix: settings values no longer exposed to dag runner

### DIFF
--- a/dags/fetch_and_save_dag_from_github.py
+++ b/dags/fetch_and_save_dag_from_github.py
@@ -1,5 +1,4 @@
 from airflow.sdk import dag, task
-from airflow import settings
 from dag_configuration import default_dag_args
 from datetime import datetime, timedelta
 import urllib.request
@@ -30,8 +29,8 @@ The following parameters are available:
 def fetch_and_save_dag_from_github(
     org: str = "", repo: str = "", ref: str = "", path: str = ""
 ):
-    wait_seconds = settings.MIN_SERIALIZED_DAG_FETCH_INTERVAL + \
-        settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL
+    # Matches legacy settings value from MIN_SERIALIZED_DAG_FETCH_INTERVAL + MIN_SERIALIZED_DAG_UPDATE_INTERVAL
+    wait_seconds = 15
 
     def get_filepath(path):
         file_name = path.split('/')[-1]


### PR DESCRIPTION
Addresses `fetch_and_save_dag_from_github.py` unable to be imported. 

Error on import from Airflow was:

```console
Traceback (most recent call last): File "/opt/airflow/dags/fetch_and_save_dag_from_github.py", line 33, in 
fetch_and_save_dag_from_github wait_seconds = 
settings.MIN_SERIALIZED_DAG_FETCH_INTERVAL + \ 
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File 
"/home/airflow/.local/lib/python3.13/site-packages/airflow/sdk/execution_time/supervisor.py", line 326, in __getattr__ raise AttributeError(f"module {settings.__name__!r} has no attribute {name!r}") AttributeError: module 'airflow.settings' has no attribute 'MIN_SERIALIZED_DAG_FETCH_INTERVAL'
```

As these were values that just came from our `values.yaml` files and haven't changed in years, this fix hard codes them in. We will be moving away from using this Dag with the bcgov/cas-registration#4715.

## Changes 🚧

- Replaced `settings.MIN_SERIALIZED_DAG_FETCH_INTERVAL` and `settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL` with hard coded value.

## To test ⚗️

Tested by importing into `airflow-dev` and running through the reserializer. ✔️
